### PR TITLE
Fixes to Grails version regex

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ if [ ! -f $BUILD_DIR/application.properties ] ; then
     exit 1
 fi
     
-GRAILS_VERSION=`grep app.grails.version $BUILD_DIR/application.properties | sed -e 's/app.grails.version=\(.*\)$/\1/g'`
+GRAILS_VERSION=`grep app\.grails\.version $BUILD_DIR/application.properties | sed -E -e 's/app\.grails\.version[ \t]*=[ \t]*([^ \t]+)[ \t]*$/\1/g'`
 
 echo "-----> Grails $GRAILS_VERSION app detected"
 


### PR DESCRIPTION
1. Escape dots in prop name. It was working because they were matching "anything", but should explicitly look for the dots.
2. Allow users to have whitespace around the equal sign and trailing space. The trailing space actually fails with Grails later on, so that's debatable if we really want that in ours, but the space around the equals sign is supported by Grails too. sed doesn't support \s, so had to use [ \t]
3. Require at least some version (i.e. don't match on nothing) by changing "*" to "?". This required use of -E flag.

I tested this out with a few different combinations and worked fine, except for trailing spaces I mentioned above failed in Grails, but was properly detected by our script.
