### PR TITLE
Add compile phase

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -81,8 +81,8 @@ if [ ! -d server ] ; then
     echo "-----> No server directory found. Adding jetty-runner 7.5.0.v20110901 automatically."
     mkdir server
     cp $GRAILS_HOME/jetty-runner-7.5.0.v20110901.jar server/jetty-runner.jar
-    echo 'vendored:7.5.0.v20110901' >> server/jettyVersion
-    echo 'vendored:7.5.0.v20110901' >> $CACHE_DIR/jettyVersion
+    echo 'vendored:7.5.0.v20110901' > server/jettyVersion
+    echo 'vendored:7.5.0.v20110901' > $CACHE_DIR/jettyVersion
 fi
 
 


### PR DESCRIPTION
Add a compile phase that only runs with grails 1.3.7. This takes care of a bug with plugins that have java dependencies.
