### PR TITLE
Added ability to specify JVM using system.properties and java.runtime.version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,9 @@ CACHE_DIR=$2
 # source in common functions
 . $BIN_DIR/common.sh
 
+curl --silent --location http://heroku-jvm-common.s3.amazonaws.com/jvm-buildpack-common.tar.gz | tar xz
+. bin/java
+
 GRAILS_DIR=".grails"
 
 check_build_status()


### PR DESCRIPTION
It was missing - I don't know why
