### PR TITLE
Solve Heroku R10 boot timeout

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -159,3 +159,7 @@ PROFILE_PATH="$BUILD_DIR/.profile.d/grails.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="/app/.jdk/bin:$PATH"' >> $PROFILE_PATH
 
+echo "-----> Compiling runner"
+$JAVA_HOME/bin/javac -d $BUILD_DIR/server -cp $BUILD_DIR/server/jetty-runner.jar $BIN_DIR/../server/*.java
+
+

--- a/bin/release
+++ b/bin/release
@@ -12,6 +12,6 @@ addons:
   heroku-postgresql:dev
 
 default_process_types:
-  web:      java \$JAVA_OPTS -jar server/jetty-runner.jar --port \$PORT target/*.war 
+  web:      java \$JAVA_OPTS -cp server/jetty-runner.jar:server -Djetty.port=\$PORT Main target/*.war 
 
 EOF

--- a/server/Main.java
+++ b/server/Main.java
@@ -1,0 +1,27 @@
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.webapp.WebAppContext;
+
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		int port = Integer.parseInt(System.getProperty("jetty.port"));
+		Server jetty = new Server(port);
+		HandlerCollection hc = new HandlerCollection ();
+		ContextHandlerCollection contextHandlerCollection = new ContextHandlerCollection();
+		hc.setHandlers(new Handler[]{contextHandlerCollection});
+		jetty.setHandler(hc);
+		jetty.start();
+
+		for(String arg : args) {
+			WebAppContext webapp = new WebAppContext();
+			webapp.setContextPath("/");
+			webapp.setWar(arg);		
+			
+			contextHandlerCollection.addHandler(webapp);
+			webapp.start();
+		}
+	}
+}


### PR DESCRIPTION
This patch forces Jetty to bind to its port early, thus avoiding the common R10 boot timeout errors that plague Grails apps on Heroku. With this patch the Grails app can take all the time it needs to start up; during startup time, requests simply fail with a 404 error, but at least the app starts reliably.

See ticket: https://help.heroku.com/tickets/84969
